### PR TITLE
Add keepalive condition

### DIFF
--- a/awsdecomm.rb
+++ b/awsdecomm.rb
@@ -188,6 +188,8 @@ class AwsDecomm < Sensu::Handler
   end
 
   def handle
+    return unless @event['check']['name'] == 'keepalive'
+      
     @b = ""
     @s = ""
     if @event['action'].eql?('create')


### PR DESCRIPTION
One thing I noticed in making my own version of this is that it'll fire on _anything_ that doesn't have a handler, so you probably want to only run the script on a keepalive firing.